### PR TITLE
Patch: Running example_vasarhelyi with `quadcopter` drone type

### DIFF
--- a/@Drone/Drone.m
+++ b/@Drone/Drone.m
@@ -570,12 +570,17 @@ classdef Drone < handle
 
             x_new = x_ode(end, :);
             self.pos_ned = x_new(1:3)';
-            if self.pos_ned_history == [NaN, NaN, NaN]
+            if isequal(self.pos_ned_history, [NaN, NaN, NaN])
                 self.pos_ned_history = self.pos_ned;
             else
                 self.pos_ned_history = [self.pos_ned_history; self.pos_ned'];
             end
             self.vel_xyz = x_new(4:6)';
+            if isempty(self.vel_xyz_history) || isequal(self.vel_xyz_history, [NaN, NaN, NaN])
+                self.vel_xyz_history = self.vel_xyz'; % rows = time steps, columns = states
+            else
+                self.vel_xyz_history = [self.vel_xyz_history; self.vel_xyz'];
+            end
             self.attitude = x_new(7:9)';
             self.rates = x_new(10:12)';
 

--- a/parameters/param_swarm/param_swarm.m
+++ b/parameters/param_swarm/param_swarm.m
@@ -112,8 +112,11 @@ end
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-p_swarm.max_a = 10;
-% p_swarm.max_a = []; % leave empty if you use a real drone model
+if DRONE_TYPE == "fixed_wing" || DRONE_TYPE == "quadcopter"
+    p_swarm.max_a = []; % leave empty if you use a real drone model
+elseif DRONE_TYPE == "point_mass"
+    p_swarm.max_a = 10;
+end
 p_swarm.max_v = 7;
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
These proposed changes are based on attempts to run `example_vasarhelyi` with `DRONE_TYPE = "quadcopter"`

First issue addressed:

- Indexing error occurs on line 287 of `Swarm.m` after the main simulation is finished but during plotting and swarm state analysis. The error seems to be because `vel_xyz_history` is empty. When `example_vasarhelyi` is run with `DRONE_TYPE = "point_mass"`, each drone's `pos_ned_history` and `vel_xyz_history` are saved by the method `Drone.update_state` (lines 376 to 387). When running `DRONE_TYPE = "quadcopter"`, `Drone.compute_kinematics` is called instead and it saves `pos_ned_history` but does not save `vel_xyz_history`. 
- This merge request suggests a modification to `Drone.compute_kinematics` to save `vel_xyz_history`. The `if` statement needs to check for an empty array because `vel_xyz_history` does not have values assigned to it prior to this point (`pos_ned_history` appears to have values assigned to it by the method `Drone.set_pos` by swarm initialization)
- I have also encapsulated the check against a vector of NaNs within an `isequal` to ensure the `if` statement does its check against a logical scalar.

Second issue addressed:

- The drones appear to spend the first part of the simulation traveling down, below an altitude of 0, before they start to maintain altitude. The file `param_swarm` includes a line that is commented out with the comment "leave empty if you use a real drone model." 
- The addition of an `if` statement that assigns a value to `p_swarm.max_a` based on `DRONE_TYPE` appears to fix the issue, and is consistent with other usages of `DRONE_TYPE` in other parameter files to assign parameter values.
- See attached plots.

![altitude_timeStep_beforeFix](https://user-images.githubusercontent.com/113978053/204581744-90d42792-be51-40c8-84c0-b00f4302e987.png)

![altitude_timeStep_afterFix](https://user-images.githubusercontent.com/113978053/204581779-54fcd998-1d8f-4a53-a0f7-8428d58e1d16.png)
